### PR TITLE
update env to fix issues with numpy nan handling in linear algebra computations when using conda

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -2,11 +2,13 @@ name: flusion
 channels:
   - defaults
 dependencies:
-  - python=3.9
-  - numpy=1.24
+  - python=3.11
+  - nomkl
+  - numpy
   - pandas
   - matplotlib
   - seaborn
+  - ipykernel
   - pip
   - pip:
     - pymmwr
@@ -16,3 +18,4 @@ dependencies:
     - lightgbm
     - "--editable=git+https://github.com/elray1/sarix.git#egg=sarix"
     - "--editable=git+https://github.com/reichlab/timeseriesutils.git#egg=timeseriesutils"
+    - "--editable=code/data-pipeline"

--- a/environment.yml
+++ b/environment.yml
@@ -8,6 +8,7 @@ dependencies:
   - pandas
   - matplotlib
   - seaborn
+  - lightgbm
   - ipykernel
   - pip
   - pip:
@@ -15,7 +16,6 @@ dependencies:
     - jax
     - jaxlib
     - numpyro
-    - lightgbm
     - "--editable=git+https://github.com/elray1/sarix.git#egg=sarix"
     - "--editable=git+https://github.com/reichlab/timeseriesutils.git#egg=timeseriesutils"
     - "--editable=code/data-pipeline"


### PR DESCRIPTION
i dug up this solution somewhere in stackoverflow in a link that i've now lost.  The main fix here is `nomkl`.  but switching to python 3.11 is probably a good idea.