### PR TITLE
add separate kwargs arguments to load_data for each data set

### DIFF
--- a/code/data-pipeline/src/data_pipeline/loader.py
+++ b/code/data-pipeline/src/data_pipeline/loader.py
@@ -67,20 +67,23 @@ class FluDataLoader():
     dat['inc'] = dat.weeklyrate
     dat['location'] = dat['region']
     dat['agg_level'] = np.where(dat['location'] == 'Entire Network', 'national', 'site')
-    dat = dat[(dat.age_label.isin(age_labels)) & (dat.location.isin(locations))]
-    if seasons is not None:
-      dat = dat[dat.season.isin(seasons)]
+    dat = dat[dat.age_label.isin(age_labels)]
     
     dat = dat.sort_values(by=['wk_end'])
     
     dat['wk_end_date'] = pd.to_datetime(dat['wk_end'])
     dat = dat[['agg_level', 'location', 'season', 'season_week', 'wk_end_date', 'inc']]
     
+    # add in data from 2022/23 season
     dat = pd.concat(
       [dat, self.load_flusurv_rates_2022_23()],
       axis = 0
     )
-
+    
+    dat = dat[dat.location.isin(locations)]
+    if seasons is not None:
+      dat = dat[dat.season.isin(seasons)]
+    
     dat['source'] = 'flusurvnet'
     
     return dat

--- a/code/data-pipeline/tests/test_load_data.py
+++ b/code/data-pipeline/tests/test_load_data.py
@@ -1,4 +1,6 @@
 from data_pipeline.loader import FluDataLoader
+import numpy as np
+import datetime
 
 def test_load_data_sources():
     fdl = FluDataLoader('../../data-raw')
@@ -15,3 +17,52 @@ def test_load_data_sources():
     
     df = fdl.load_data()
     assert set(df['source'].unique()) == {'flusurvnet', 'hhs', 'ilinet'}
+
+
+def test_load_data_kwargs():
+    fdl = FluDataLoader('../../data-raw')
+    
+    # hhs_kwargs
+    df_hhs1 = fdl.load_data(sources=['hhs'])
+    df_hhs2 = fdl.load_data(
+        sources=['hhs'],
+        hhs_kwargs={
+            'drop_pandemic_seasons': False
+        })
+    df_hhs3 = fdl.load_data(
+        sources=['hhs'],
+        hhs_kwargs={
+            'drop_pandemic_seasons': True,
+            'as_of': datetime.date.fromisoformat('2023-12-30')
+        })
+
+    assert df_hhs1['season'].min() == '2022/23'
+    assert df_hhs2['season'].min() == '2019/20'
+    assert df_hhs3['season'].min() == '2022/23'
+    assert str(df_hhs1['wk_end_date'].max())[:10] > '2023-12-23'
+    assert str(df_hhs2['wk_end_date'].max())[:10] > '2023-12-23'
+    assert str(df_hhs3['wk_end_date'].max())[:10] == '2023-12-23'
+    
+    # ilinet_kwargs
+    df_ilinet1 = fdl.load_data(sources=['ilinet'])
+    df_ilinet2 = fdl.load_data(
+        sources=['ilinet'],
+        ilinet_kwargs={'drop_pandemic_seasons': True})
+    df_ilinet3 = fdl.load_data(
+        sources=['ilinet'],
+        ilinet_kwargs={'drop_pandemic_seasons': False})
+    
+    # in first two results, pandemic season incidence set to NA
+    assert np.all(df_ilinet1.loc[df_ilinet1['season'].isin(['2008/09', '2009/10', '2020/21', '2021/22']), 'inc'].isna())
+    assert np.all(df_ilinet2.loc[df_ilinet2['season'].isin(['2008/09', '2009/10', '2020/21', '2021/22']), 'inc'].isna())
+    # in third result, some non-NA values in pandemic seasons
+    assert np.any(~df_ilinet3.loc[df_ilinet1['season'].isin(['2008/09', '2009/10', '2020/21', '2021/22']), 'inc'].isna())
+    
+    #flusurv_kwargs
+    df_flusurv1 = fdl.load_data(sources=['flusurvnet'])
+    df_flusurv2 = fdl.load_data(
+        sources=['flusurvnet'],
+        flusurvnet_kwargs={'locations': ['California', 'Colorado', 'Connecticut']})
+    
+    assert len(df_flusurv1['location'].unique()) > 3
+    assert len(df_flusurv2['location'].unique()) == 3


### PR DESCRIPTION
would resolve #13 

also addresses the first two points under #21 


Running tests from within `code/data-pipeline` succeeds, other than a lot of warnings related to Pandas/Numpy interactions that are not in our control.

```
(flusion) eray@ubuntu:~/research/epi/flu/flusion/code/data-pipeline$ pytest
============================================================================================= test session starts =============================================================================================
platform linux -- Python 3.11.0, pytest-7.4.0, pluggy-1.0.0
rootdir: /home/eray/research/epi/flu/flusion/code/data-pipeline
collected 2 items                                                                                                                                                                                             

tests/test_load_data.py ..                                                                                                                                                                              [100%]

============================================================================================== warnings summary ===============================================================================================
tests/test_load_data.py: 146 warnings
  /home/eray/miniconda3/envs/flusion/lib/python3.11/site-packages/pandas/core/algorithms.py:522: DeprecationWarning: np.find_common_type is deprecated.  Please use `np.result_type` or `np.promote_types`.
  See https://numpy.org/devdocs/release/1.25.0-notes.html and the docs for more information.  (Deprecated NumPy 1.25)
    common = np.find_common_type([values.dtype, comps_array.dtype], [])

tests/test_load_data.py: 42 warnings
  /home/eray/miniconda3/envs/flusion/lib/python3.11/site-packages/pandas/core/dtypes/cast.py:1641: DeprecationWarning: np.find_common_type is deprecated.  Please use `np.result_type` or `np.promote_types`.
  See https://numpy.org/devdocs/release/1.25.0-notes.html and the docs for more information.  (Deprecated NumPy 1.25)
    return np.find_common_type(types, [])

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
================================================================================= 2 passed, 188 warnings in 68.94s (0:01:08) ==================================================================================
```